### PR TITLE
Handle invalid transforms in panel projection

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -138,7 +138,8 @@ void MainWindow::paintEvent(QPaintEvent *)
         qreal dx      = origin.x() + panelW * 0.5 - windowW * 0.5;
         qreal dy      = origin.y() + panelH * 0.5 - windowH * 0.5;
         qreal xyDist  = std::hypot(dx, dy);
-        qreal xyF     = D / (D + xyDist / 10.0); // более мягкое влияние
+        qreal s       = qAbs(qSin(qDegreesToRadians(normAng)));
+        qreal xyF     = D / (D + xyDist / 10.0 * s); // более мягкое влияние
 
         qreal factor = depthF * xyF;
 
@@ -220,10 +221,11 @@ void MainWindow::paintEvent(QPaintEvent *)
 
             // 2) рисуем саму панель, маппя квадрат на произвольный четырёхугольник
             QTransform t;
-            QTransform::quadToQuad(srcQuad, dstQuad, t);
-            p.setTransform(t, /*combine=*/ false);
-            p.drawPixmap(0, 0, panelW, panelH, pix);
-            p.resetTransform();
+            if (QTransform::quadToQuad(srcQuad, dstQuad, t)) {
+                p.setTransform(t, /*combine=*/ false);
+                p.drawPixmap(0, 0, panelW, panelH, pix);
+                p.resetTransform();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix perspective scaling so panels return to rectangle after flip
- avoid invalid QTransform by checking `quadToQuad` result

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68764bbb449883298f28a7b7a8629628