### PR TITLE
Add panel inertia swing effect

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -28,6 +28,8 @@ void MainWindow::startFlipAnimation()
         panel.progress = 0.0;
         panel.angle    = 0.0;
         panel.flipped  = false;
+        panel.swingAmplitude = 0.0;
+        panel.swingPhase     = 0.0;
     }
 
     m_animTimer.start();
@@ -57,6 +59,15 @@ void MainWindow::animateStep()
                 if (!panel.flipped && (panel.angle >= 90)) {
                     panel.flipped = true;
                 }
+                if (panel.progress >= 1.0) {
+                    panel.swingAmplitude = 30.0; // start swing in degrees
+                    panel.swingPhase     = 0.0;
+                }
+                allDone = false;
+            } else if (panel.swingAmplitude > 0.5) {
+                panel.swingPhase += 0.3;       // speed of oscillation
+                panel.swingAmplitude *= 0.90;  // damping
+                panel.angle = 180.0 + panel.swingAmplitude * qSin(panel.swingPhase);
                 allDone = false;
             }
         }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -24,6 +24,10 @@ private:
         qreal progress = 0.0; // 0..1 progress of the flip
         qreal angle    = 0.0; // cached angle for painting
         bool  flipped  = false;
+
+        // Parameters for post-flip oscillation
+        qreal swingAmplitude = 0.0; // in degrees
+        qreal swingPhase     = 0.0;
     };
 
 


### PR DESCRIPTION
## Summary
- add swing amplitude and phase parameters to each panel
- update animation step to start and decay swing after flipping

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687653249304832981dfd6681887b5b2